### PR TITLE
Fix PermissionError in log file access

### DIFF
--- a/deploy_raspberry_pi.sh
+++ b/deploy_raspberry_pi.sh
@@ -127,6 +127,8 @@ fi
 
 # 9. Log Directory Setup
 mkdir -p logs
+# Fix permissions in case logs directory was previously created by root
+sudo chown -R $(whoami): logs
 
 # 10. systemd Service Installation
 echo ""
@@ -154,7 +156,7 @@ StartLimitBurst=5
 StartLimitIntervalSec=600
 
 # Logging
-StandardOutput=append:$WORKING_DIR/logs/bot.log
+# StandardOutput removed to avoid permission conflict with application logging
 StandardError=append:$WORKING_DIR/logs/bot.error.log
 
 [Install]


### PR DESCRIPTION
This PR fixes a `PermissionError` when the bot attempts to write to `logs/bot.log`. 

The issue was caused by the systemd service configuration redirecting `StandardOutput` to `logs/bot.log`. When systemd starts the service, it creates this file as `root` (if it doesn't exist). The Python application, running as a non-root user (`pi`), then fails to open the file with `RotatingFileHandler`.

Changes:
- Removed `StandardOutput=append:.../logs/bot.log` from `deploy_raspberry_pi.sh`. The application handles its own logging to `bot.log`, and having systemd also write to it causes conflict and permission issues.
- Added `sudo chown -R $USER: logs` in `deploy_raspberry_pi.sh` to ensure the user owns the logs directory and files, fixing the issue if the files were previously created by root.

`StandardError` is kept as is, pointing to `logs/bot.error.log`. Since the Python application doesn't open this file directly (it writes to stderr which systemd captures), this does not cause a permission error for the application.

---
*PR created automatically by Jules for task [3122186489109014380](https://jules.google.com/task/3122186489109014380) started by @philibertschlutzki*