### PR TITLE
Fix: Enforce valid API key configuration and improve .env visibility

### DIFF
--- a/deploy_raspberry_pi.sh
+++ b/deploy_raspberry_pi.sh
@@ -35,10 +35,11 @@ echo "------------------------------"
 
 if [ ! -f .env ]; then
     cp .env.example .env
+    echo "ℹ️  Created .env file (hidden)"
 fi
 
 # Check if PAT already exists in .env
-if grep -q "GITHUB_PAT=" .env && [ -n "$(grep GITHUB_PAT= .env | cut -d '=' -f2)" ]; then
+if grep -q "^GITHUB_PAT=" .env && [ -n "$(grep "^GITHUB_PAT=" .env | cut -d '=' -f2)" ]; then
     echo "✅ GitHub PAT already configured in .env"
 else
     echo "Please create a GitHub Personal Access Token:"
@@ -69,7 +70,8 @@ echo ""
 echo "🔑 Gemini API Configuration"
 echo "----------------------------"
 
-if grep -q "GEMINI_API_KEY=" .env && [ -n "$(grep GEMINI_API_KEY= .env | cut -d '=' -f2)" ]; then
+GEMINI_KEY_VAL=$(grep "^GEMINI_API_KEY=" .env | cut -d '=' -f2)
+if grep -q "^GEMINI_API_KEY=" .env && [ -n "$GEMINI_KEY_VAL" ] && [ "$GEMINI_KEY_VAL" != "your_gemini_api_key_here" ]; then
     echo "✅ Gemini API Key already configured in .env"
 else
     echo "Please create a Gemini API Key:"
@@ -86,14 +88,18 @@ else
         exit 1
     fi
 
-    echo "GEMINI_API_KEY=$GEMINI_API_KEY" >> .env
+    if grep -q "^GEMINI_API_KEY=your_gemini_api_key_here" .env; then
+         sed -i "s|^GEMINI_API_KEY=.*|GEMINI_API_KEY=$GEMINI_API_KEY|" .env
+    else
+         echo "GEMINI_API_KEY=$GEMINI_API_KEY" >> .env
+    fi
     echo "✅ Gemini API Key configured!"
 fi
 
 # 6. Git Remote Configuration
 echo ""
 echo "🔧 Configuring Git remote with PAT..."
-GITHUB_PAT=$(grep GITHUB_PAT= .env | cut -d '=' -f2)
+GITHUB_PAT=$(grep "^GITHUB_PAT=" .env | cut -d '=' -f2)
 REPO_URL=$(git config --get remote.origin.url)
 
 # Extract owner/repo from current URL
@@ -184,3 +190,4 @@ fi
 
 echo ""
 echo "🎉 Deployment complete!"
+echo "ℹ️  Note: Configuration is stored in .env (hidden file). Use 'ls -a' to view."

--- a/main.py
+++ b/main.py
@@ -490,9 +490,9 @@ def single_run():
 
 def main_loop():
     """Infinite loop for 24/7 operation"""
-    if not GEMINI_API_KEY:
+    if not GEMINI_API_KEY or GEMINI_API_KEY == "your_gemini_api_key_here":
         error_msg = (
-            "❌ GEMINI_API_KEY nicht gesetzt!\n"
+            "❌ GEMINI_API_KEY nicht gesetzt (oder Placeholder gefunden)!\n"
             "   Bitte führe das Deployment-Skript erneut aus:\n"
             "   ./deploy_raspberry_pi.sh\n"
             "   Oder setze den Key manuell in der .env Datei:\n"


### PR DESCRIPTION
The issue was that `deploy_raspberry_pi.sh` considered the default placeholder value in `.env` as a valid configuration, leading to a false success message. Also, users were confused by `.env` being hidden.
This PR fixes the check logic to reject the placeholder, correctly updates the `.env` file, and adds UX improvements to clarify where the configuration is stored. It also safeguards `main.py` against running with the placeholder key.

---
*PR created automatically by Jules for task [10804302214140341904](https://jules.google.com/task/10804302214140341904) started by @philibertschlutzki*