### PR TITLE
⚡ Optimize market analysis loop by caching active bets

### DIFF
--- a/main.py
+++ b/main.py
@@ -455,15 +455,16 @@ def single_run():
     top_markets = pre_filter_markets(raw_markets, top_n=TOP_MARKETS_TO_ANALYZE)
 
     # 4. Analyze and save new bets
-    for i, market in enumerate(top_markets):
-        # Prevent Gemini Rate Limits
-        time.sleep(3)
+    active_slugs = {b['market_slug'] for b in database.get_active_bets()}
 
+    for i, market in enumerate(top_markets):
         # Check if we already have an active bet on this market?
-        active_slugs = [b['market_slug'] for b in database.get_active_bets()]
         if market.market_slug in active_slugs:
             logger.info(f"⏭️  Bereits aktive Wette für: {market.market_slug}. Skipping.")
             continue
+
+        # Prevent Gemini Rate Limits
+        time.sleep(3)
 
         rec = analyze_and_recommend(market, capital)
 
@@ -479,6 +480,7 @@ def single_run():
                 'expected_value': rec.expected_value,
                 'end_date': market.end_date
             })
+            active_slugs.add(market.market_slug)
     
     # 5. Update dashboard if needed
     if dashboard.should_update_dashboard():


### PR DESCRIPTION
*   💡 **What:** Moved `database.get_active_bets()` outside the main market loop and cached active slugs in a set. Moved the `time.sleep(3)` rate limit delay to occur *after* the active bet check.
*   🎯 **Why:** The previous implementation queried the database for every market in the loop, causing O(N) database calls. It also slept for 3 seconds even when skipping already active bets.
*   📊 **Measured Improvement:**
    *   **DB Calls:** Reduced from N (e.g., 20) to 1.
    *   **Time Saved:** In a simulation with 20 markets (10 active), execution time dropped from ~60s to ~30s, saving 30s of unnecessary sleep time.
    *   **Lookup Speed:** Checking existence in a set is O(1) vs O(N) for list.

---
*PR created automatically by Jules for task [6677694189505518280](https://jules.google.com/task/6677694189505518280) started by @philibertschlutzki*