### PR TITLE
Fix: ValueError in SQLite Timestamp Conversion (Issue #51)

### DIFF
--- a/database.py
+++ b/database.py
@@ -73,6 +73,9 @@ def get_db_connection():
     Handles nested usage by tracking recursion depth.
     """
     if not hasattr(_local, "connection") or _local.connection is None:
+        # Ensure adapters are registered for this thread/connection
+        register_adapters()
+
         conn = sqlite3.connect(
             DB_NAME,
             detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES,

--- a/tests/test_issue_51.py
+++ b/tests/test_issue_51.py
@@ -1,0 +1,56 @@
+import unittest
+import sqlite3
+import threading
+import datetime
+from database import get_db_connection
+
+class TestIssue51(unittest.TestCase):
+    def setUp(self):
+        # Setup a clean state or use temporary table
+        pass
+
+    def test_timestamp_converter_in_new_thread(self):
+        """
+        Verify that the timestamp converter works correctly in a new thread.
+        This reproduces the scenario where a new connection is created in a thread
+        and needs the adapters to be registered.
+        """
+        def run_test(result_container):
+            try:
+                with get_db_connection() as conn:
+                    cursor = conn.cursor()
+                    # Create a temp table to avoid messing with real data
+                    cursor.execute("CREATE TEMPORARY TABLE IF NOT EXISTS test_issue_51 (ts TIMESTAMP)")
+                    cursor.execute("DELETE FROM test_issue_51")
+
+                    # Insert a date-only string (raw)
+                    conn.execute("INSERT INTO test_issue_51 (ts) VALUES (?)", ("2023-10-27",))
+                    conn.commit()
+
+                    # Read back
+                    cursor.execute("SELECT ts FROM test_issue_51")
+                    row = cursor.fetchone()
+                    val = row['ts']
+
+                    result_container['val'] = val
+                    result_container['type'] = type(val)
+            except Exception as e:
+                result_container['error'] = e
+
+        result = {}
+        t = threading.Thread(target=run_test, args=(result,))
+        t.start()
+        t.join()
+
+        if 'error' in result:
+            self.fail(f"Thread failed with error: {result['error']}")
+
+        self.assertIsInstance(result.get('val'), datetime.datetime,
+                              f"Expected datetime object, got {result.get('type')}: {result.get('val')}")
+        # Check that date-only was converted to midnight
+        self.assertEqual(result['val'].hour, 0)
+        self.assertEqual(result['val'].minute, 0)
+        self.assertEqual(result['val'].second, 0)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR addresses Issue #51 where the bot crashed with `ValueError: not enough values to unpack` when parsing timestamps on Python 3.13.

The root cause was that the custom `flexible_timestamp_converter` was not being reliably used for new thread-local connections, causing SQLite to fall back to the default converter which failed on date-only strings (e.g. `YYYY-MM-DD`).

Changes:
- Updated `database.py` to call `register_adapters()` before creating a new SQLite connection in `get_db_connection()`.
- Added `tests/test_issue_51.py` to reproduce the issue in a threaded environment and verify the fix.

Verified by running the new regression test and existing tests.


---
*PR created automatically by Jules for task [1253467920744869301](https://jules.google.com/task/1253467920744869301) started by @philibertschlutzki*