### PR TITLE
Fix TypeError in dashboard due to Decimal/float division

### DIFF
--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -192,14 +192,14 @@ def _generate_performance_metrics(results, metrics):
 
 
 def _generate_risk_metrics(active_bets, capital):
-    total_exposure = sum(b["stake_usdc"] for b in active_bets)
+    total_exposure = sum(float(b["stake_usdc"]) for b in active_bets)
     exposure_pct = (total_exposure / capital * 100) if capital > 0 else 0
     avg_position = total_exposure / len(active_bets) if active_bets else 0
-    largest_stake = max((b["stake_usdc"] for b in active_bets), default=0)
+    largest_stake = max((float(b["stake_usdc"]) for b in active_bets), default=0)
     largest_pct = (largest_stake / capital * 100) if capital > 0 else 0
 
     if total_exposure > 0:
-        stakes = [b["stake_usdc"] for b in active_bets]
+        stakes = [float(b["stake_usdc"]) for b in active_bets]
         hhi = sum((s / total_exposure) ** 2 for s in stakes)
     else:
         hhi = 0


### PR DESCRIPTION
This PR fixes a `TypeError: unsupported operand type(s) for /: 'decimal.Decimal' and 'float'` that occurred in `src/dashboard.py` when calculating portfolio risk metrics.

The issue was caused by `stake_usdc` values being returned as `decimal.Decimal` objects from the database (via SQLAlchemy), while `capital` was a `float`. Python does not support direct division between these types.

The fix involves explicitly casting `stake_usdc` to `float` before performing arithmetic operations in the `_generate_risk_metrics` function.

I have verified the fix with a reproduction script and confirmed that existing tests pass.

---
*PR created automatically by Jules for task [4618360269544056052](https://jules.google.com/task/4618360269544056052) started by @philibertschlutzki*